### PR TITLE
Include child bundles

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ const streamifier = require('streamifier');
 const am = require('appcache-manifest');
 
 function reduceBundles(bundles) {
-    const result = [];
+    let result = [];
     bundles.forEach(function (bundle) {
         result.push(bundle.name);
-        result.concat(reduceBundles(bundle.childBundles));
+        result = result.concat(reduceBundles(bundle.childBundles));
     });
     return result;
 }


### PR DESCRIPTION
`Array.prototype.concat` does not mutate the original array. This commit allows child bundles to be included in the appcache